### PR TITLE
Column Tonerow support

### DIFF
--- a/src/twelve_tone/composer.py
+++ b/src/twelve_tone/composer.py
@@ -27,11 +27,16 @@ class Composer(object):
         otherwise the top most tone row will be returned.
         """
         melody = []
-        tone_row = column if column else row
+        tone_row = self._get_tone_row(row, column)
 
-        for cell in self.matrix[tone_row]:
+        for cell in tone_row:
             melody.append(self.get_pitch(int(cell)))
         return melody
+
+    def _get_tone_row(self, row, column):
+        if column:
+            return self.matrix[:, column]
+        return self.matrix[row]
 
     def save_to_midi(self, tone_rows=1, filename='example.mid'):
         m = MIDIFile(filename=filename)

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -5,6 +5,14 @@ from twelve_tone.composer import Composer
 
 class TestMatrix(unittest.TestCase):
 
+    def test_get_tone_row(self):
+        m = Composer()
+        m.compose()
+        row = m._get_tone_row(1, None)
+        self.assertEquals(list(row), list(m.matrix[1]))
+        col = m._get_tone_row(0, 1)
+        self.assertEquals(list(col), list(m.matrix[:, 1]))
+
     def test_top_row(self):
         m = Composer().compose()
         # check top row is unique


### PR DESCRIPTION
This allows you to specify a column number and then use that column for the tone row instead of the horizontal row in `Composer.get_melody`.

resolves #3 