### PR TITLE
Mention alternative installation with Guix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,8 @@ Installation
 
     pip install twelve-tone
 
+The `GuixRUs <https://git.sr.ht/~whereiseveryone/guixrus>`_ channel also provides ``twelve-tone``.
+
 Quick Start
 ===========
 


### PR DESCRIPTION
Hi,

I packaged `python-twelve-tone` for [guix](guix.gnu.org) and put it in a channel called [GuixRUS](https://git.sr.ht/~whereiseveryone/guixrus
) that I maintain with some other guix upstream contributors.

Once subscribed to the channel you can install it like this:

`guix install twelve-tone`